### PR TITLE
BugFix #37 : adapt overlay image size to the preview

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -79,6 +79,7 @@ COUNTDOWN_OVERLAY_IMAGES=[
     os.path.join("ressources","count_down_4.png"),
     os.path.join("ressources","count_down_5.png"),
     os.path.join("ressources","count_down_ready.png")]
+COUNTDOWN_IMAGE_MAX_HEIGHT_RATIO = 0.2 #(0. - 1.) Ratio of the countdown images over screen height
 
 EMAIL_BUTTON_IMG  = os.path.join("ressources","ic_email.png")
 OAUTH2_REFRESH_PERIOD = 1800000 # interval between two OAuth2 token refresh (ms)

--- a/scripts/user_interface.py
+++ b/scripts/user_interface.py
@@ -550,7 +550,7 @@ class UserInterface():
         preview_width = preview_size[0]
         preview_height = preview_size[1]
         
-        overlay_height = int(preview_height * 0.2)
+        overlay_height = int(preview_height * COUNTDOWN_IMAGE_MAX_HEIGHT_RATIO)
         #print preview_size
         #print preview_width, preview_height, overlay_height
         

--- a/scripts/user_interface.py
+++ b/scripts/user_interface.py
@@ -546,11 +546,18 @@ class UserInterface():
         #bbox = self.camera.preview.window
         #preview_width = bbox[2]
         #preview_height = bbox[3]
-        preview_size = self.camera.resolution
-        preview_width = preview_size[0]
-        preview_height = preview_size[1]
+        #preview_size = self.camera.resolution
+
         
-        overlay_height = int(preview_height * COUNTDOWN_IMAGE_MAX_HEIGHT_RATIO)
+        screen_width = self.root.winfo_screenwidth()
+        screen_height = self.root.winfo_screenheight()
+        
+        #I'm making the bet that preview window size == screen size in fullscreen mode
+        #If this fails we should try preview_width = min(screen_width, self.camera.resolution[0])
+        preview_width = screen_width
+        preview_height = screen_height
+        
+        overlay_height = int(preview_height * COUNTDOWN_IMAGE_MAX_HEIGHT_RATIO) 
         #print preview_size
         #print preview_width, preview_height, overlay_height
         


### PR DESCRIPTION
- [X] Move the hardcoded size ratio into `constants.py`
- [x] Base the overlay size  on screen_height instead of camera resolution
- [ ] Test for consistency